### PR TITLE
Remove deprecated stanza and OS dep

### DIFF
--- a/Casks/anka-virtualization@2.5.7.148.rb
+++ b/Casks/anka-virtualization@2.5.7.148.rb
@@ -4,12 +4,11 @@ cask "anka-virtualization@2.5.7.148" do
   
     url "https://downloads.veertu.com/anka/Anka-#{version}.pkg",
     verified: "downloads.veertu.com/anka/"
-    appcast "https://ankadocs.veertu.com/docs/release-notes/"
     name "Anka Virtualization"
     desc "CLI tool for managing and creating virtual machines"
     homepage "https://veertu.com/"
   
-    depends_on macos: ">= :yosemite"
+    depends_on macos: ">= :big_sur"
   
     pkg "Anka-#{version}.pkg"
   

--- a/Casks/anka-virtualization@3.0.1.144.rb
+++ b/Casks/anka-virtualization@3.0.1.144.rb
@@ -3,8 +3,7 @@ cask "anka-virtualization@3.0.1.144" do
     sha256 "04c39bdc570c95a3a0ab54d8335263d9ee53680d1c7b5952bd15e1dd1c87b681"
   
     url "https://downloads.veertu.com/anka/Anka-#{version}.pkg",
-        verified: "downloads.veertu.com/anka/"
-    appcast "https://ankadocs.veertu.com/docs/release-notes/"
+    verified: "downloads.veertu.com/anka/"
     name "Anka Virtualization"
     desc "CLI tool for managing and creating virtual machines"
     homepage "https://veertu.com/"


### PR DESCRIPTION
`appcast` is no longer a valid stanza. Yosemite is no longer a valid option for the macos version dependency block.

https://docs.brew.sh/Cask-Cookbook#requiring-an-exact-macos-release